### PR TITLE
chore: add missing semicolon to karma-test-shim

### DIFF
--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -20,7 +20,7 @@ System.config({
               // creates local module name mapping to global path with karma's fingerprint in path, e.g.:
               // './hero.service': '/base/src/app/hero.service.js?f4523daf879cfb7310ef6242682ccf10b2041b3e'
               var moduleName = appPath.replace(/^\/base\/src\/app\//, './').replace(/\.js$/, '');
-              pathsMapping[moduleName] = appPath + '?' + window.__karma__.files[appPath]
+              pathsMapping[moduleName] = appPath + '?' + window.__karma__.files[appPath];
               return pathsMapping;
             }, {})
 


### PR DESCRIPTION
I a ported this workflow to [ng-bootstrap](https://github.com/ng-bootstrap/core) and our clang was doing crazy things, it was due that semicolon which would put the return on the same line and cry.

Thanks for extracting the idea in here Julie, I was able to write tests at last :)