### PR TITLE
making karma-test-shim.js / karma.conf.js a bit more reusable

### DIFF
--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -13,7 +13,9 @@ System.config({
   packages: {
     'base/src/app': {
       defaultExtension: false,
-      format: 'register',
+      // see your tsconfig.json -- its important that the package is set up correctly
+      // When the module format is not set, automatic regular-expression-based detection is used. 
+      //format: 'register',
       map: Object.keys(window.__karma__.files).
             filter(onlyAppFiles).
             reduce(function createPathRecords(pathsMapping, appPath) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,6 +9,7 @@ module.exports = function(config) {
       // paths loaded by Karma
       {pattern: 'node_modules/systemjs/dist/system.src.js', included: true, watched: true},
       {pattern: 'node_modules/angular2/bundles/angular2.js', included: true, watched: true},
+      {pattern: 'node_modules/angular2/bundles/http.js', included: true, watched: true},      
       {pattern: 'node_modules/angular2/bundles/testing.js', included: true, watched: true},
       {pattern: 'karma-test-shim.js', included: true, watched: true},
       {pattern: 'src/test/matchers.js', included: true, watched: true},


### PR DESCRIPTION
- changes karma.conf.js to have relaxed systemjs-packages-config
- adds http.js by default

I usually compile my typescript code to CommonJS format. For a test project I used the same folder structure and wondered why the shim was not working out-of-the box. The reason was the package-format in `karma-test-shim.js` (format: register). I would prefer the automatic module format detection, see:
https://github.com/systemjs/systemjs/blob/master/docs/module-formats.md#module-format-detection 
