### PR TITLE
The cp multiple file syntax using {}, as used by...

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "postinstall": "typings install --ambient",
     "clean": "rimraf built/",
-    "copy": "cp src/{index.html,styles.css,system-config.js} built/",
-    "copytemplates": "cp src/app/{*.html,*.css} built/app/",
+    "copy": "cp src/index.html src/styles.css src/system-config.js built/",
+    "copytemplates": "cp src/app/*.html src/app/*.css built/app/",
     "build": "tsc && npm run copy && npm run copytemplates",
     "watch": "tsc --watch",
     "serve": "http-server -p 9090 -c-1",


### PR DESCRIPTION
 the copy and copytemplates scripts, does not work on my Ubuntu 16.04 machine.
Considering the small number of files involved, I think it's a reasonable
work-around to simply enumerate the relevant files w/o the {} format.

[npm-debug.txt](https://github.com/juliemr/ng2-test-seed/files/353387/npm-debug.txt)

